### PR TITLE
Only perform filter if search string is present

### DIFF
--- a/src/ng2-smart-table/lib/data-source/local/local.data-source.ts
+++ b/src/ng2-smart-table/lib/data-source/local/local.data-source.ts
@@ -235,14 +235,18 @@ export class LocalDataSource extends DataSource {
     if (this.filterConf.filters) {
       if (this.filterConf.andOperator) {
         this.filterConf.filters.forEach((fieldConf: any) => {
-          data = LocalFilter
-            .filter(data, fieldConf['field'], fieldConf['search'], fieldConf['filter']);
+          if (fieldConf['search'].length > 0) {
+            data = LocalFilter
+              .filter(data, fieldConf['field'], fieldConf['search'], fieldConf['filter']);
+          }
         });
       } else {
         let mergedData: any = [];
         this.filterConf.filters.forEach((fieldConf: any) => {
-          mergedData = mergedData.concat(LocalFilter
-            .filter(data, fieldConf['field'], fieldConf['search'], fieldConf['filter']));
+          if (fieldConf['search'].length > 0) {
+            mergedData = mergedData.concat(LocalFilter
+              .filter(data, fieldConf['field'], fieldConf['search'], fieldConf['filter']));
+          }
         });
         // remove non unique items
         data = mergedData.filter((elem: any, pos: any, arr: any) => {


### PR DESCRIPTION
**Problem**

Column filters are run regardless of whether or not search input has been provided by the user. For example, on bootstrap of the example app provided in this repo, `localFilter.filter` method is run 110 times. 

**Solution**

When looping through each filter, check `fieldConf['search']` and only filter the data if a search string is present.